### PR TITLE
Adapt for 4.6.1: wp-includes/js/tinymce/wp-tinymce.php

### DIFF
--- a/wp-entry-points.md
+++ b/wp-entry-points.md
@@ -30,7 +30,7 @@
 
 1. wp-links-opml.php:15 ???
 1. wp-includes/ms-files.php:12 ???
-1. wp-includes/js/tinymce/wp-mce-help.php:9 ???
+1. wp-includes/js/tinymce/wp-tinymce.php
 1. wp-admin/install-helper.php:39 ???
 1. wp-admin/moderation.php:10 ???
 


### PR DESCRIPTION
wp-includes/js/tinymce/wp-tinymce.php seems an entry point.
wp-mce-help.php has been removed.

Note: almost any file requir'ing wp-admin.php inside wp-admin/ could be considered a valid entry point.